### PR TITLE
Permission isEmailConfirm MT-130

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -8,6 +8,8 @@ from accounts.serializers import (
     ProfileSerializer,
     UserSerializer,
 )
+from chat.permissions import IsEmailConfirm
+
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import validate_email
@@ -26,7 +28,7 @@ from backend.accounts.services.email import send_password_reset_email
 class UserAPIView(APIView):
     """Return current authenticated user"""
 
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, IsEmailConfirm)
     parser_classes = [JSONParser, MultiPartParser, FormParser]
     serializer_class = UserSerializer
 
@@ -79,7 +81,7 @@ class ProfileAPIView(RetrieveUpdateAPIView):
     Get, Update user avatar
     """
 
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, IsEmailConfirm)
     queryset = Profile.objects.all()
     serializer_class = ProfileSerializer
     http_method_names = ["get", "put"]
@@ -101,7 +103,7 @@ class ChangePasswordAPIView(UpdateAPIView):
 
     serializer_class = ChangePasswordSerializer
     model = User
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, IsEmailConfirm)
     http_method_names = ["put"]
 
     @extend_schema(

--- a/backend/chat/permissions.py
+++ b/backend/chat/permissions.py
@@ -4,6 +4,8 @@ from rest_framework import permissions
 class IsCreatorOrReadOnly(permissions.BasePermission):
     """Permission to update. Check that request is from the obj creator."""
 
+    message = "The action is allowed only to the author"
+
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
             return True
@@ -15,9 +17,20 @@ class IsCreatorOrReadOnly(permissions.BasePermission):
 class IsOnlyDescriptionInRequestData(permissions.BasePermission):
     """Permission to update chat description. Check that request has only a description field."""
 
+    message = "Only the chat description can be changed"
+
     def has_object_permission(self, request, view, obj):
         if request.method != "PATCH":
             return True
         # is only description field in request
         is_only_description = len(request.data) == 1 and "description" in request.data
         return is_only_description
+
+
+class IsEmailConfirm(permissions.BasePermission):
+    """Permission. Checking that email is confirmed."""
+
+    message = "The email address is unconfirmed."
+
+    def has_permission(self, request, view):
+        return request.user.is_email_confirmed

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -1,5 +1,5 @@
 from chat.models import Chat
-from chat.permissions import IsCreatorOrReadOnly, IsOnlyDescriptionInRequestData
+from chat.permissions import IsCreatorOrReadOnly, IsOnlyDescriptionInRequestData, IsEmailConfirm
 from chat.serializer import ChatSerializer, MessageSerializer
 from config.settings import CHOICE_ROOM
 from rest_framework import generics, status
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 class ChatAPIView(generics.GenericAPIView):
     """API to get/put chat"""
 
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, IsEmailConfirm)
     parser_classes = [JSONParser, MultiPartParser, FormParser]
     serializer_class = ChatSerializer
     http_method_names = ["get", "post"]
@@ -59,7 +59,7 @@ class ChatAPIView(generics.GenericAPIView):
 class UpdateDeleteChatApiView(generics.RetrieveUpdateDestroyAPIView):
     """Update chat description or delete chat"""
 
-    permission_classes = (IsAuthenticated, IsCreatorOrReadOnly, IsOnlyDescriptionInRequestData)
+    permission_classes = (IsAuthenticated, IsCreatorOrReadOnly, IsOnlyDescriptionInRequestData, IsEmailConfirm)
     queryset = Chat.objects.all()
     serializer_class = ChatSerializer
     http_method_names = ["patch", "delete"]
@@ -68,7 +68,7 @@ class UpdateDeleteChatApiView(generics.RetrieveUpdateDestroyAPIView):
 class MessagesApiView(generics.ListAPIView):
     """Get messages from the certain chat"""
 
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, IsEmailConfirm)
     serializer_class = MessageSerializer
     http_method_names = ["get"]
 

--- a/doc/ChatAPI.md
+++ b/doc/ChatAPI.md
@@ -193,7 +193,27 @@
 
         ```json
         {
-            "detail": "You do not have permission to perform this action."
+            "type": "client_error",
+            "errors": [
+                {
+                    "code": "permission_denied",
+                    "detail": "The action is allowed only to the author",
+                    "attr": null
+                }
+            ]
+        }
+        ```
+
+        ```json
+        {
+            "type": "client_error",
+            "errors": [
+                {
+                    "code": "permission_denied",
+                    "detail": "Only the chat description can be changed",
+                    "attr": null
+                }
+            ]
         }
         ```
 

--- a/doc/Registration.md
+++ b/doc/Registration.md
@@ -83,5 +83,19 @@
         ```
 
 -   Additional information:  
-    In case of a response with a status code of 201, the user will be sent a link to confirm his email. Link in mail: URL = http://<UIHost>/confirm-email/?token_id=<token>.  
+    In case of a response with a status code of 201, the user will be sent a link to confirm his email. Link in mail: URL = http://<UIHost>/confirm-email/?token_id=<token>.
     To confirm email and change the variable is_email_confirm to True you should do Get request to URL = https://prod-chat.duckdns.org/api/confirm-email/?token_id=<token>.
+    -   You can't get/post... information if the email is unconfirmed. You will get the following error:
+
+        ```json
+         {
+             "type": "client_error",
+             "errors": [
+                 {
+                     "code": "permission_denied",
+                     "detail": "The email address is unconfirmed.",
+                     "attr": null
+                 }
+             ]
+         }
+        ```


### PR DESCRIPTION
Permission that doesn't allow users with unconfirmed emails to use Views.